### PR TITLE
update:修改在分享到朋友圈的时候，第一次弹出是否授权保存权限，如果点否，则后续无法再次弹出授权弹窗，并无法保存图片

### DIFF
--- a/litemall-wx/pages/goods/goods.js
+++ b/litemall-wx/pages/goods/goods.js
@@ -30,7 +30,8 @@ Page({
     collectImage: '/static/images/icon_collect.png',
     shareImage: '',
     isGroupon: false, //标识是否是一个参团购买
-    soldout: false
+    soldout: false,
+    canWrite: false, //用户是否获取了保存相册的权限
   },
 
   // 页面分享
@@ -53,7 +54,27 @@ Page({
       return false;
     }
   },
-
+  handleSetting: function(e) {
+      var that = this;
+      // console.log(e)
+      if (!e.detail.authSetting['scope.writePhotosAlbum']) {
+          wx.showModal({
+              title: '警告',
+              content: '不授权无法保存',
+              showCancel: false
+          })
+          that.setData({
+              canWrite: false
+          })
+      } else {
+          wx.showToast({
+              title: '保存成功'
+          })
+          that.setData({
+              canWrite: true
+          })
+      }
+  },
   // 保存分享图
   saveShare: function() {
     let that = this;
@@ -399,6 +420,32 @@ Page({
       });
       this.getGrouponInfo(options.grouponId);
     }
+    let that = this;
+    wx.getSetting({
+        success: function (res) {
+            console.log(res)
+            //不存在相册授权
+            if (!res.authSetting['scope.writePhotosAlbum']) {
+                wx.authorize({
+                    scope: 'scope.writePhotosAlbum',
+                    success: function () {
+                        that.setData({
+                            canWrite: true
+                        })
+                    },
+                    fail: function (err) {
+                        that.setData({
+                            canWrite: false
+                        })
+                    }
+                })
+            } else {
+                that.setData({
+                    canWrite: true
+                });
+            }
+        }
+    })
   },
   onShow: function() {
     // 页面显示

--- a/litemall-wx/pages/goods/goods.wxml
+++ b/litemall-wx/pages/goods/goods.wxml
@@ -19,7 +19,11 @@
           <image class='sharebtn_image' src='/static/images/wechat.png'></image>
           <view class='sharebtn_text'>分享给好友</view>
         </button>
-        <button class="savesharebtn" bindtap="saveShare" wx:if="{{!isGroupon}}">
+        <button  class="savesharebtn" open-type="openSetting" bindopensetting="handleSetting" wx:if="{{(!isGroupon) && (!canWrite)}}" >
+          <image class='sharebtn_image' src='/static/images/friend.png'></image>
+          <view class='sharebtn_text'>发朋友圈</view>
+        </button>
+        <button class="savesharebtn" bindtap="saveShare" wx:if="{{!isGroupon && canWrite}}">
           <image class='sharebtn_image' src='/static/images/friend.png'></image>
           <view class='sharebtn_text'>发朋友圈</view>
         </button>

--- a/renard-wx/pages/goods/goods.js
+++ b/renard-wx/pages/goods/goods.js
@@ -30,7 +30,8 @@ Page({
     collectImage: '/static/images/icon_collect.png',
     shareImage: '',
     isGroupon: false, //标识是否是一个参团购买
-    soldout: false
+    soldout: false,
+    canWrite: false
   },
 
   // 页面分享
@@ -42,7 +43,27 @@ Page({
       path: '/pages/index/index?goodId=' + this.data.id
     }
   },
-
+  handleSetting: function(e) {
+      var that = this;
+      // console.log(e)
+      if (!e.detail.authSetting['scope.writePhotosAlbum']) {
+          wx.showModal({
+              title: '警告',
+              content: '不授权无法保存',
+              showCancel: false
+          })
+          that.setData({
+              canWrite: false
+          })
+      } else {
+          wx.showToast({
+              title: '保存成功'
+          })
+          that.setData({
+              canWrite: true
+          })
+      }
+  },
   showShare: function() {
     this.sharePop.togglePopup();
   },
@@ -375,6 +396,33 @@ Page({
       });
       this.getGrouponInfo(options.grouponId);
     }
+    let that = this;
+    wx.getSetting({
+        success: function (res) {
+            console.log(res)
+            //不存在相册授权
+            if (!res.authSetting['scope.writePhotosAlbum']) {
+                wx.authorize({
+                    scope: 'scope.writePhotosAlbum',
+                    success: function () {
+                        that.setData({
+                            canWrite: true
+                        })
+                    },
+                    fail: function (err) {
+                        that.setData({
+                            canWrite: false
+                        })
+                    }
+                })
+            } else {
+                that.setData({
+                    canWrite: true
+                });
+            }
+        }
+    })
+
   },
 
   onShow: function() {

--- a/renard-wx/pages/goods/goods.wxml
+++ b/renard-wx/pages/goods/goods.wxml
@@ -134,7 +134,10 @@
 
 <!-- 底部按钮 -->
 <view class="bottom-btn">
-  <view class="l l-collect" bindtap="showShare" wx:if="{{!isGroupon}}">
+  <view class="l l-collect"open-type="openSetting" bindopensetting="handleSetting" wx:if="{{(!isGroupon) && (!canWrite) }}">
+    <image class="icon" src="../../images/goods-share.png" />
+  </view>
+  <view class="l l-collect" bindtap="showShare" wx:if="{{!isGroupon && canWrite}}">
     <image class="icon" src="../../images/goods-share.png" />
   </view>
   <view class="l l-cart" wx:if="{{!isGroupon}}">


### PR DESCRIPTION
之前的分享按钮，当用户第一次点击分享到朋友圈时，会询问是否授权。此时如果拒绝，后续不再弹出是否授权，并无法保存图片到手机。现改为，在进入商品详情时，询问是否授权，此时用户如果拒绝。然后点击分享到朋友圈按钮，则会打开微信的授权列表。这里根据微信在去年的一次更新，无法使用opensetting，只能通过展示授权列表来让用户授权。希望采纳~~~！