### PR TITLE
修复进入商品详情加载商品评论时，因评论用户信息不存在的情况导致的NullPoint异常。

### DIFF
--- a/litemall-wx-api/src/main/java/org/linlinjava/litemall/wx/web/WxGoodsController.java
+++ b/litemall-wx-api/src/main/java/org/linlinjava/litemall/wx/web/WxGoodsController.java
@@ -130,8 +130,8 @@ public class WxGoodsController {
 				c.put("addTime", comment.getAddTime());
 				c.put("content", comment.getContent());
 				LitemallUser user = userService.findById(comment.getUserId());
-				c.put("nickname", user.getNickname());
-				c.put("avatar", user.getAvatar());
+				c.put("nickname", user == null ? "" : user.getNickname());
+				c.put("avatar", user == null ? "" : user.getAvatar());
 				c.put("picList", comment.getPicUrls());
 				commentsVo.add(c);
 			}


### PR DESCRIPTION
因用户信息是NULL导致异常。