### PR TITLE
添加swagger和设置编译级别为1.8

### DIFF
--- a/litemall-admin-api/pom.xml
+++ b/litemall-admin-api/pom.xml
@@ -21,12 +21,18 @@
             <groupId>org.linlinjava</groupId>
             <artifactId>litemall-db</artifactId>
         </dependency>
-
         <dependency>
             <groupId>com.github.binarywang</groupId>
             <artifactId>weixin-java-miniapp</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>io.springfox</groupId>
+            <artifactId>springfox-swagger-ui</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.springfox</groupId>
+            <artifactId>springfox-swagger2</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.apache.shiro</groupId>
             <artifactId>shiro-spring-boot-web-starter</artifactId>

--- a/litemall-admin-api/src/main/java/org/linlinjava/litemall/admin/config/Swagger2Configuration.java
+++ b/litemall-admin-api/src/main/java/org/linlinjava/litemall/admin/config/Swagger2Configuration.java
@@ -1,0 +1,44 @@
+package org.linlinjava.litemall.admin.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import springfox.documentation.builders.ApiInfoBuilder;
+import springfox.documentation.builders.PathSelectors;
+import springfox.documentation.builders.RequestHandlerSelectors;
+import springfox.documentation.service.ApiInfo;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spring.web.plugins.Docket;
+import springfox.documentation.swagger2.annotations.EnableSwagger2;
+
+/**
+ * swagger在线文档配置<br>
+ * 项目启动后可通过地址：http://host:ip/swagger-ui.html 查看在线文档
+ * @version 2018-07-24
+ *
+ * @author enilu
+ */
+
+@Configuration
+@EnableSwagger2
+public class Swagger2Configuration {
+    @Bean
+    public Docket createRestApi() {
+
+        return new Docket(DocumentationType.SWAGGER_2)
+                .apiInfo(apiInfo())
+                .select()
+                .apis(RequestHandlerSelectors.basePackage("org.linlinjava.litemall.admin.web"))
+                .paths(PathSelectors.any())
+                .build();
+    }
+
+    private ApiInfo apiInfo() {
+        return new ApiInfoBuilder()
+                .title("litemall-admin api")
+                .description("开源商城后台管理平台")
+                .termsOfServiceUrl("https://github.com/linlinjava/litemall")
+                .contact("https://github.com/linlinjava/litemall")
+                .version("1.0")
+                .build();
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -141,6 +141,16 @@
                 <artifactId>spring-boot-starter-mail</artifactId>
                 <version>2.0.4.RELEASE</version>
             </dependency>
+            <dependency>
+                <groupId>io.springfox</groupId>
+                <artifactId>springfox-swagger2</artifactId>
+                <version>2.2.2</version>
+            </dependency>
+            <dependency>
+                <groupId>io.springfox</groupId>
+                <artifactId>springfox-swagger-ui</artifactId>
+                <version>2.2.2</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -183,6 +183,15 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.1</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
- 设置默认的编译级别为1.8，否则使用Intellij IDEA打开的时候总是默认为1.7导致编译不通过
- 添加swagger配置自动生成在线api接口文档