### PR TITLE
修复了用户订单列表点击去支付无法正常跳转

### DIFF
--- a/litemall-vue/src/views/items/category/index.vue
+++ b/litemall-vue/src/views/items/category/index.vue
@@ -64,7 +64,7 @@ export default {
     handleTabClick(index) {
       this.categoryId = this.navList[index].id;
       this.$router.replace({
-        name: 'list',
+        name: 'category',
         query: { itemClass: this.categoryId }
       });
       this.init();

--- a/litemall-vue/src/views/user/order-list/index.vue
+++ b/litemall-vue/src/views/user/order-list/index.vue
@@ -42,7 +42,7 @@
               <van-button size="small"
                           v-if="el.handleOption.pay"
                           type="danger"
-                          @click="toPay(el.id)">去支付</van-button>
+                          @click.stop="toPay(el.id)">去支付</van-button>
               <van-button size="small"
                           v-if="el.handleOption.refund"
                           type="danger"


### PR DESCRIPTION
用户订单列表点击去支付会跳到支付页面然后马上跳到订单详情，没有阻止冒泡事件