### PR TITLE
fix[litemall-admin]: 修复查看商品详情时, 图片溢出

### DIFF
--- a/litemall-admin/src/views/goods/list.vue
+++ b/litemall-admin/src/views/goods/list.vue
@@ -62,7 +62,7 @@
       <el-table-column align="center" label="详情" prop="detail">
         <template slot-scope="scope">
           <el-dialog :visible.sync="detailDialogVisible" title="商品详情">
-            <div v-html="goodsDetail" />
+            <div class="goods-detail-box" v-html="goodsDetail" />
           </el-dialog>
           <el-button type="primary" size="mini" @click="showDetail(scope.row.detail)">查看</el-button>
         </template>
@@ -122,6 +122,9 @@
   .gallery {
     width: 80px;
     margin-right: 10px;
+  }
+  .goods-detail-box img {
+    width: 100%;
   }
 </style>
 


### PR DESCRIPTION
修复之前
![image](https://user-images.githubusercontent.com/15064137/70371549-47524800-190f-11ea-83b8-0515d3910053.png)

修复之后
![image](https://user-images.githubusercontent.com/15064137/70371543-2f7ac400-190f-11ea-935c-6fc655bf4329.png)
