### PR TITLE
发送邮件通知使用ssl方式,大多数服务器都禁用了25端口

### DIFF
--- a/litemall-core/src/main/java/org/linlinjava/litemall/core/notify/config/NotifyAutoConfiguration.java
+++ b/litemall-core/src/main/java/org/linlinjava/litemall/core/notify/config/NotifyAutoConfiguration.java
@@ -11,6 +11,8 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.JavaMailSenderImpl;
 
+import java.util.Properties;
+
 @Configuration
 @EnableConfigurationProperties(NotifyProperties.class)
 public class NotifyAutoConfiguration {
@@ -59,6 +61,17 @@ public class NotifyAutoConfiguration {
         mailSender.setHost(mailConfig.getHost());
         mailSender.setUsername(mailConfig.getUsername());
         mailSender.setPassword(mailConfig.getPassword());
+        mailSender.setPort(mailConfig.getPort());
+        Properties properties = new Properties();
+        properties.put("mail.smtp.auth",true);
+        properties.put("mail.smtp.timeout",5000);
+        properties.put("mail.smtp.starttls.enable",true);
+        properties.put("mail.smtp.socketFactory.fallback", "false");
+        //阿里云 必须加入配置 outlook配置又不需要 视情况而定.发送不成功多数是这里的配置问题
+        properties.put("mail.smtp.socketFactory.class", "javax.net.ssl.SSLSocketFactory");
+        properties.put("mail.smtp.socketFactory.port", mailConfig.getPort());
+        properties.put("debug", true);
+        mailSender.setJavaMailProperties(properties);
         return mailSender;
     }
 

--- a/litemall-core/src/main/java/org/linlinjava/litemall/core/notify/config/NotifyProperties.java
+++ b/litemall-core/src/main/java/org/linlinjava/litemall/core/notify/config/NotifyProperties.java
@@ -43,7 +43,7 @@ public class NotifyProperties {
         private String password;
         private String sendfrom;
         private String sendto;
-
+        private Integer port;
         public boolean isEnable() {
             return enable;
         }
@@ -90,6 +90,14 @@ public class NotifyProperties {
 
         public void setSendto(String sendto) {
             this.sendto = sendto;
+        }
+
+        public Integer getPort() {
+            return port;
+        }
+
+        public void setPort(Integer port) {
+            this.port = port;
         }
     }
 

--- a/litemall-core/src/main/resources/application-core.yml
+++ b/litemall-core/src/main/resources/application-core.yml
@@ -20,7 +20,7 @@ litemall:
       password: XXXXXXXXXXXXX
       sendfrom: ex@ex.com.cn
       sendto: ex@qq.com
-
+      port: 465
     # 短消息模版通知配置
     # 短信息用于通知客户，例如发货短信通知，注意配置格式；template-name，template-templateId 请参考 NotifyType 枚举值
     sms:


### PR DESCRIPTION
解决25端口邮件发送不成功问题