### PR TITLE
[FIX] 新建完收货地址，假如立即选择地址会退回编辑界面，以致[参数不正确]的错误

### DIFF
--- a/litemall-vue/src/views/user/module-address-edit/index.vue
+++ b/litemall-vue/src/views/user/module-address-edit/index.vue
@@ -45,7 +45,7 @@ export default {
     onSave(content) {
       addressSave(content).then(res => {
         this.$toast('成功');
-        this.$router.push({ path: '/user/address' });
+        this.$router.go(-1);
       });
     },
     onDelete(content) {


### PR DESCRIPTION
修改```module-address-edit/index.vue```中的```onSave```方法，路由跳转到上一页面，而不是```user/address```。

```javascript
onSave(content) {
      addressSave(content).then(res => {
        this.$toast('成功');
        this.$router.go(-1);
//        this.$router.push({ path: '/user/address' });
      });
    },
```