### PR TITLE
Add Index on litemall_goods_product.goods_id

### DIFF
--- a/litemall-db/sql/litemall_table.sql
+++ b/litemall-db/sql/litemall_table.sql
@@ -378,7 +378,8 @@ CREATE TABLE `litemall_goods_product` (
   `add_time` datetime DEFAULT NULL COMMENT '创建时间',
   `update_time` datetime DEFAULT NULL COMMENT '更新时间',
   `deleted` tinyint(1) DEFAULT '0' COMMENT '逻辑删除',
-  PRIMARY KEY (`id`)
+  PRIMARY KEY (`id`),
+  KEY `goods_id` (`goods_id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=251 DEFAULT CHARSET=utf8mb4 COMMENT='商品货品表';
 /*!40101 SET character_set_client = @saved_cs_client */;
 


### PR DESCRIPTION
Adding index on table `litemall_goods_product` column `goods_id` might speed up the underlying query issued via `productService.queryByGid(id)`. See #329 