### PR TITLE
 Add Index on litemall_groupon_rules.goods_id

### DIFF
--- a/litemall-db/sql/litemall_table.sql
+++ b/litemall-db/sql/litemall_table.sql
@@ -446,7 +446,8 @@ CREATE TABLE `litemall_groupon_rules` (
   `add_time` datetime NOT NULL COMMENT '创建时间',
   `update_time` datetime DEFAULT NULL COMMENT '更新时间',
   `deleted` tinyint(1) DEFAULT '0' COMMENT '逻辑删除',
-  PRIMARY KEY (`id`) USING BTREE
+  PRIMARY KEY (`id`) USING BTREE,
+  KEY `goods_id` (`goods_id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=4 DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC COMMENT='团购规则表';
 /*!40101 SET character_set_client = @saved_cs_client */;
 


### PR DESCRIPTION
Adding index on table `litemall_groupon_rules` column `goods_id` might speed up the underlying query issued via `rulesService.queryByGoodsId(id)`. See #331 