### PR TITLE
fix[litemall-wx-api]: 下标越界的问题

### DIFF
--- a/litemall-wx-api/src/main/java/org/linlinjava/litemall/wx/web/WxCatalogController.java
+++ b/litemall-wx-api/src/main/java/org/linlinjava/litemall/wx/web/WxCatalogController.java
@@ -63,7 +63,9 @@ public class WxCatalogController {
         if (id != null) {
             currentCategory = categoryService.findById(id);
         } else {
-            currentCategory = l1CatList.get(0);
+             if (l1CatList.size() > 0) {
+                currentCategory = l1CatList.get(0);
+            }
         }
 
         // 当前一级分类目录对应的二级分类目录


### PR DESCRIPTION
当l1CatList长度为0的时候会出现下标越界的情况