### PR TITLE
解决mysql-connector-java为8.0.16时MyBatis Generator无法生成XXXByPrimaryKey相关方法

### DIFF
--- a/litemall-db/mybatis-generator/generatorConfig.xml
+++ b/litemall-db/mybatis-generator/generatorConfig.xml
@@ -43,7 +43,7 @@
 
         <!--数据库连接信息-->
         <jdbcConnection driverClass="com.mysql.cj.jdbc.Driver"
-                        connectionURL="jdbc:mysql://127.0.0.1:3306/litemall?useUnicode=true&amp;characterEncoding=UTF-8&amp;serverTimezone=UTC&amp;verifyServerCertificate=false&amp;useSSL=false"
+                        connectionURL="jdbc:mysql://127.0.0.1:3306/litemall?useUnicode=true&amp;characterEncoding=UTF-8&amp;serverTimezone=UTC&amp;verifyServerCertificate=false&amp;useSSL=false&amp;nullCatalogMeansCurrent=true"
                         userId="litemall"
                         password="litemall123456"/>
 


### PR DESCRIPTION
**问题**：mysql-connector-java为8.0.16时MyBatis Generator自动生成代码提示：[WARNING] Cannot obtain primary key information from the database, generated objects may be incomplete。无法生成XXXByPrimaryKey相关方法。
**解决**：（本次提交使用方法2）

- 方法1、mysql-connector-java使用5.X版本
- 方法2、在jdbc url后增加 ?nullCatalogMeansCurrent=true。