### PR TITLE
方便本地部署 litemall-admin，以及修复拼写错误等

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ Servers
 .metadata
 upload
 gen_code
+
+### database data ignore ###
+docker/db/data

--- a/docker/README.md
+++ b/docker/README.md
@@ -13,6 +13,10 @@
     cnpm install
     cnpm run build:dep
     
+    cd ../litemall-vue
+    cnpm install
+    cnpm run build:dep
+   
     cd ..
     mvn clean package
     cp -f ./litemall-all/target/litemall-all-*-exec.jar ./docker/litemall/litemall.jar

--- a/litemall-admin/.env.deployment
+++ b/litemall-admin/.env.deployment
@@ -1,8 +1,8 @@
 NODE_ENV = production
 
 # just a flag
-ENV = 'deploymenet'
+ENV = 'deployment'
 
 # base api
-VUE_APP_BASE_API = 'http://122.51.199.160:8080/admin'
+VUE_APP_BASE_API = 'http://localhost:8080/admin'
 


### PR DESCRIPTION
1. 修复 litemall-admin 项目下 .env.deployment 中的拼写错误；
2. 修复 litemall-admin 项目deployment部署的base api 为localhost，方便本地测试；
3. 修改 docker 目录下的 README.md，完善 docker 快速部署脚本；
4. 修改 .gitignore，忽略 mysql docker 实例在 data 目录下生成的文件。