### PR TITLE
小程序中增加对promise.finally操作的支持

### DIFF
--- a/litemall-wx/app.js
+++ b/litemall-wx/app.js
@@ -4,6 +4,17 @@ var user = require('./utils/user.js');
 
 App({
   onLaunch: function() {
+    Promise.prototype.finally = function(callback){
+      let P = this.constructor;
+      return this.then(
+              value => {
+                   P.resolve(callback()).then(() => value)
+               },
+               reason => {
+                   P.resolve(callback()).then(() => { throw reason })
+               }
+           )
+    }
     const updateManager = wx.getUpdateManager();
     wx.getUpdateManager().onUpdateReady(function() {
       wx.showModal({

--- a/renard-wx/app.js
+++ b/renard-wx/app.js
@@ -4,7 +4,20 @@ var user = require('./utils/user.js');
 
 App({
   onLaunch: function() {
+    Promise.prototype.finally = function(callback){
+      let P = this.constructor;
+      return this.then(
+              value => {
+                   P.resolve(callback()).then(() => value)
+               },
+               reason => {
+                   P.resolve(callback()).then(() => { throw reason })
+               }
+           )
+    }
+
     const updateManager = wx.getUpdateManager();
+    
     wx.getUpdateManager().onUpdateReady(function() {
       wx.showModal({
         title: '更新提示',


### PR DESCRIPTION
小程序开发环境在promise 中支持 finally 操作，但在真机中有情况下会报错。在app.js中对 Promise 的 prototype 进行扩展，以便支持finally操作。