### PR TITLE
fix[litemall-wx]: ScrollView高度设置增加像素单位

### DIFF
--- a/litemall-wx/pages/category/category.wxml
+++ b/litemall-wx/pages/category/category.wxml
@@ -6,7 +6,7 @@
       </view>
     </scroll-view>
   </view>
-  <scroll-view scroll-y="true" scroll-top="{{scrollTop}}" style="height:{{scrollHeight}};">
+  <scroll-view scroll-y="true" scroll-top="{{scrollTop}}" style="height:{{scrollHeight}}px;">
 
     <view class="cate-item">
       <view class="h">


### PR DESCRIPTION
没有像素单位会导致高度设置无效