### PR TITLE
Introduce fixed JDK versions and an OpenJDK distro to support it

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,14 +11,16 @@ jobs:
       matrix:
         java-version:
         - 8
+        - 8.0.192
         - 11
+        - 11.0.3
     steps:
     - uses: actions/checkout@v2
     - name: Set up JDK ${{ matrix.java-version }}
       uses: actions/setup-java@v2
       with:
         java-version: ${{ matrix.java-version }}
-        distribution: adopt
+        distribution: temurin
     - name: Cache Maven packages
       uses: actions/cache@v2
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
       uses: actions/setup-java@v2
       with:
         java-version: ${{ matrix.java-version }}
-        distribution: temurin
+        distribution: zulu
     - name: Cache Maven packages
       uses: actions/cache@v2
       with:


### PR DESCRIPTION
Now when the fixed version is green and the latest version is red, you'll know the problem is with the latest version specifically, Zulu support this since it has all the historical major and minor JDK versions.