### PR TITLE
Bug fix: 参数不对 in the admin when updating a L2 category

### DIFF
--- a/litemall-admin-api/src/main/java/org/linlinjava/litemall/admin/vo/CategoryVo.java
+++ b/litemall-admin-api/src/main/java/org/linlinjava/litemall/admin/vo/CategoryVo.java
@@ -10,6 +10,7 @@ public class CategoryVo {
     private String iconUrl;
     private String picUrl;
     private String level;
+    private Integer pid;
     private List<CategoryVo> children;
 
     public List<CategoryVo> getChildren() {
@@ -74,5 +75,13 @@ public class CategoryVo {
 
     public void setLevel(String level) {
         this.level = level;
+    }
+
+    public Integer getPid() {
+        return pid;
+    }
+
+    public void setPid(Integer pid) {
+        this.pid = pid;
     }
 }

--- a/litemall-admin-api/src/main/java/org/linlinjava/litemall/admin/web/AdminCategoryController.java
+++ b/litemall-admin-api/src/main/java/org/linlinjava/litemall/admin/web/AdminCategoryController.java
@@ -56,6 +56,7 @@ public class AdminCategoryController {
                 subCategoryVo.setKeywords(subCategory.getKeywords());
                 subCategoryVo.setName(subCategory.getName());
                 subCategoryVo.setLevel(subCategory.getLevel());
+                subCategoryVo.setPid(subCategory.getPid());
 
                 children.add(subCategoryVo);
             }


### PR DESCRIPTION
**Problem**: Updating a L2 (level 2) category in the admin causes a failure.

The admin API forgets to send the `pid` (parent ID) of L2 categories.
Therefore, when updating a L2 category, the `validate()` method in `AdminCategoryController.java` fails because its `pid` is `null`.

**Solution**: Add the `pid` of L2 categories in the data sent from `/admin/category/list`.